### PR TITLE
refactor(ci): update evm version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Install EVM assembler
+      - name: Shallow-clone EVM assembler
         run: git clone --depth 1 --revision ce7ad588c737f2d11d3f8b55ec427a611a540c2f --recurse-submodules --shallow-submodules --no-tags https://github.com/wjmelements/evm.git
 
       - name: Build EVM assembler


### PR DESCRIPTION
The latest evm version (v0.1.0) requires `--recurse-submodules`
#### Changes
* update evm version by pinning a newer commit
* shallow clone with `--depth 1` and `--shallow-submodules`
* separate steps for build and install